### PR TITLE
XREAL Air Demo

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,8 @@ android {
 
     defaultConfig {
         applicationId "com.collabora.xrgears"
-        minSdkVersion 24
+        // 26 is minimal for ActivityOptions.setLaunchDisplayId()
+        minSdkVersion 26
         // Version 30 breaks loader
         targetSdkVersion 29
         versionCode 1
@@ -24,6 +25,11 @@ android {
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_shared'
+            }
+
+            // If necessary, limit app ABI to match ABI of libraries that was built 
+            ndk {
+                abiFilters 'arm64-v8a'
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,25 @@
           android:versionName="1.0"
     android:installLocation="auto" >
 
+  <uses-feature
+      android:glEsVersion="0x00030002"
+      android:required="true" />
+
+  <uses-feature
+      android:name="android.hardware.vr.headtracking"
+      android:required="true"
+      android:version="1" />
+
+  <uses-permission android:name="org.khronos.openxr.permission.OPENXR" />
+  <uses-permission android:name="org.khronos.openxr.permission.OPENXR_SYSTEM" />
+
+  <uses-permission android:name="android.hardware.usb.host" />
+
+  <queries>
+    <provider
+        android:authorities="org.khronos.openxr.runtime_broker;org.khronos.openxr.system_runtime_broker"/>
+  </queries>
+
   <!-- This .apk has no Java code itself, so set hasCode to false. -->
   <application
       android:allowBackup="false"
@@ -12,21 +31,31 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:label="@string/app_name"
-      android:hasCode="false">
+      android:hasCode="true">
 
-    <activity android:name="android.app.NativeActivity"
+    <activity android:name="com.collabora.xrgears.XrGears"
               android:label="@string/app_name"
         android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
-        android:launchMode="singleTask"
+        android:launchMode="singleTop"
+        android:excludeFromRecents="true"
+        android:taskAffinity="cover.container"
         android:screenOrientation="landscape"
-        android:excludeFromRecents="false"
+        android:noHistory="true"
         android:configChanges="screenSize|screenLayout|orientation|keyboardHidden|keyboard|navigation|uiMode">
       <!-- Tell NativeActivity the name of our .so -->
       <meta-data android:name="android.app.lib_name"
                  android:value="xrgears" />
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
-        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+    <activity
+        android:name=".PresentationWithMediaRouterActivity"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
   </application>

--- a/app/src/main/java/com/collabora/xrgears/PresentationWithMediaRouterActivity.java
+++ b/app/src/main/java/com/collabora/xrgears/PresentationWithMediaRouterActivity.java
@@ -1,0 +1,166 @@
+package com.collabora.xrgears;
+
+import android.app.Activity;
+import android.app.ActivityOptions;
+import android.app.MediaRouteActionProvider;
+import android.app.Presentation;
+import android.content.Context;
+import android.content.Intent;
+import android.media.MediaRouter;
+import android.media.MediaRouter.RouteInfo;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Display;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.TextView;
+
+
+/**
+ * <h3>Presentation Activity</h3>
+ *
+ * <p>
+ * This demonstrates how to create an activity that shows some content
+ * on a secondary display using a {@link Presentation}.
+ * </p><p>
+ * The activity uses the {@link MediaRouter} API to automatically detect when
+ * a presentation display is available and to allow the user to control the
+ * media routes using a menu item.  When a presentation display is available,
+ * we stop showing content in the main activity and instead open up a
+ * {@link Presentation} on the preferred presentation display.  When a presentation
+ * display is removed, we revert to showing content in the main activity.
+ * We also write information about displays and display-related events to
+ * the Android log which you can read using <code>adb logcat</code>.
+ * </p><p>
+ * You can try this out using an HDMI or Wifi display or by using the
+ * "Simulate secondary displays" feature in Development Settings to create a few
+ * simulated secondary displays.  Each display will appear in the list along with a
+ * checkbox to show a presentation on that display.
+ * </p><p>
+ * See also the {@link PresentationActivity} sample which
+ * uses the low-level display manager to enumerate displays and to show multiple
+ * simultaneous presentations on different displays.
+ * </p>
+ */
+public final class PresentationWithMediaRouterActivity extends Activity {
+    private final String TAG = "PresentationWithMediaRouterActivity";
+
+    private MediaRouter mMediaRouter;
+    private Intent mPresentation;
+    private Display mCurrentDisplay;
+    private TextView mInfoTextView;
+//    private boolean mPaused;
+
+    /**
+     * Initialization of the Activity after it is first created.  Must at least
+     * call {@link Activity#setContentView setContentView()} to
+     * describe what is to be displayed in the screen.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        // Be sure to call the super class.
+        super.onCreate(savedInstanceState);
+
+        // Get the media router service.
+        mMediaRouter = (MediaRouter)getSystemService(Context.MEDIA_ROUTER_SERVICE);
+
+        // See assets/res/any/layout/presentation_with_media_router_activity.xml for this
+        // view layout definition, which is being set here as
+        // the content of our screen.
+        setContentView(R.layout.presentation_with_media_router_activity);
+
+        // Get a text view where we will show information about what's happening.
+        mInfoTextView = (TextView)findViewById(R.id.info);
+    }
+
+    @Override
+    protected void onResume() {
+        // Be sure to call the super class.
+        super.onResume();
+
+        // Listen for changes to media routes.
+        mMediaRouter.addCallback(MediaRouter.ROUTE_TYPE_LIVE_VIDEO, mMediaRouterCallback);
+
+        // Update the presentation based on the currently selected route.
+        updatePresentation();
+    }
+
+    @Override
+    protected void onPause() {
+        // Be sure to call the super class.
+        super.onPause();
+
+        // Stop listening for changes to media routes.
+        mMediaRouter.removeCallback(mMediaRouterCallback);
+
+        updateContents();
+    }
+
+    private Display getPresentationDisplay() {
+        // Get the current route and its presentation display.
+        RouteInfo route = mMediaRouter.getSelectedRoute(
+                MediaRouter.ROUTE_TYPE_LIVE_VIDEO);
+        Display presentationDisplay = route != null ? route.getPresentationDisplay() : null;
+        return presentationDisplay;
+    };
+
+    private void updatePresentation() {
+        Display presentationDisplay = getPresentationDisplay();
+
+        // Dismiss the current presentation if the display has changed.
+        if (mPresentation != null && mCurrentDisplay != presentationDisplay) {
+                Log.i(TAG, "Dismissing presentation because the current route no longer "
+                        + "has a presentation display.");
+                mPresentation = null;
+        }
+
+        // Show a new presentation if needed.
+        if (mPresentation == null && presentationDisplay != null) {
+            Log.i(TAG, "Showing presentation on display: " + presentationDisplay);
+
+
+            Intent myIntent = new Intent(getBaseContext(), XrGears.class);
+            myIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            
+            Bundle opts = ActivityOptions
+                    .makeBasic()
+                    .setLaunchDisplayId(presentationDisplay.getDisplayId())
+                    .toBundle();
+
+            getBaseContext().startActivity(myIntent, opts);
+
+
+            mPresentation = myIntent;
+
+            mCurrentDisplay = presentationDisplay;
+        }
+
+        // Update the contents playing in this activity.
+        updateContents();
+    }
+
+    private void updateContents() {
+        // Show either the content in the main activity or the content in the presentation
+        // along with some descriptive text about what is happening.
+        Display presentation_display = getPresentationDisplay();
+        if (mPresentation != null && presentation_display != null) {
+            mInfoTextView.setText(getResources().getString(
+                    R.string.presentation_with_media_router_now_playing_remotely,
+                    presentation_display.getName()));
+        } else {
+            mInfoTextView.setText(getResources().getString(
+                    R.string.presentation_with_media_router_now_playing_locally,
+                    getWindowManager().getDefaultDisplay().getName()));
+        }
+    }
+
+    private final MediaRouter.SimpleCallback mMediaRouterCallback =
+            new MediaRouter.SimpleCallback() {
+                @Override
+                public void onRoutePresentationDisplayChanged(MediaRouter router, RouteInfo info) {
+                    Log.d(TAG, "onRoutePresentationDisplayChanged: info=" + info);
+                    updatePresentation();
+                }
+            };
+
+}

--- a/app/src/main/java/com/collabora/xrgears/UsbDPActivity.java
+++ b/app/src/main/java/com/collabora/xrgears/UsbDPActivity.java
@@ -1,0 +1,57 @@
+package com.collabora.xrgears;
+
+import android.app.AlertDialog;
+import android.app.NativeActivity;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+import android.os.Bundle;
+import android.os.SystemClock;
+
+import java.util.HashMap;
+
+public class UsbDPActivity extends NativeActivity {
+    
+    private static final String ACTION_USB_PERMISSION = ".USB_PERMISSION";
+
+    private final BroadcastReceiver usbDetachReceiver = new BroadcastReceiver() {
+        public void onReceive(Context context, Intent intent) {
+            if(intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED))
+                finishAndRemoveTask();;
+        }
+    };
+
+    protected void configureUsbDetach() {
+        PendingIntent mPermissionIntent = PendingIntent.getBroadcast(getBaseContext(), 0, new Intent(ACTION_USB_PERMISSION), 0);
+
+        UsbManager usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
+        HashMap<String, UsbDevice> deviceList = usbManager.getDeviceList();
+        for (UsbDevice usbDevice : deviceList.values()) {
+            usbManager.requestPermission(usbDevice, mPermissionIntent);
+            while (!usbManager.hasPermission(usbDevice))
+            {
+                SystemClock.sleep(500);
+            }
+        }
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        registerReceiver(usbDetachReceiver, filter);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+
+        configureUsbDetach();
+
+        // Be sure to call the super class.
+        super.onCreate(savedInstanceState);
+    }
+
+
+}

--- a/app/src/main/java/com/collabora/xrgears/UsbDPActivity.java
+++ b/app/src/main/java/com/collabora/xrgears/UsbDPActivity.java
@@ -1,11 +1,9 @@
 package com.collabora.xrgears;
 
-import android.app.AlertDialog;
 import android.app.NativeActivity;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
@@ -22,15 +20,22 @@ public class UsbDPActivity extends NativeActivity {
     private final BroadcastReceiver usbDetachReceiver = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
             if(intent.getAction().equals(UsbManager.ACTION_USB_DEVICE_DETACHED))
-                finishAndRemoveTask();;
+                finishAndRemoveTask();
         }
     };
 
     protected void configureUsbDetach() {
-        PendingIntent mPermissionIntent = PendingIntent.getBroadcast(getBaseContext(), 0, new Intent(ACTION_USB_PERMISSION), 0);
+        PendingIntent mPermissionIntent = PendingIntent.getBroadcast(getBaseContext(), 0,
+                new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
 
         UsbManager usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
-        HashMap<String, UsbDevice> deviceList = usbManager.getDeviceList();
+        HashMap<String, UsbDevice> deviceList = new HashMap<>();
+
+        while (deviceList.values().size() == 0){
+            deviceList = usbManager.getDeviceList();
+            SystemClock.sleep(500);
+        }
+
         for (UsbDevice usbDevice : deviceList.values()) {
             usbManager.requestPermission(usbDevice, mPermissionIntent);
             while (!usbManager.hasPermission(usbDevice))

--- a/app/src/main/java/com/collabora/xrgears/XrGears.java
+++ b/app/src/main/java/com/collabora/xrgears/XrGears.java
@@ -1,0 +1,5 @@
+package com.collabora.xrgears;
+
+public class XrGears extends UsbDPActivity {
+
+}

--- a/app/src/main/res/layout/presentation_with_media_router_activity.xml
+++ b/app/src/main/res/layout/presentation_with_media_router_activity.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- See corresponding Java code PresentationWithMediaRouterActivity.java. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+    <!-- Message to show to use. -->
+    <TextView android:id="@+id/text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:gravity="center_vertical|center_horizontal"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:text="@string/presentation_with_media_router_activity_text"/>
+
+    <!-- Some information about what's going on. -->
+    <TextView android:id="@+id/info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:gravity="center_vertical|center_horizontal"
+        android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
-    <string name="app_name">xrgears</string>
+<string name="app_name">xrgears</string>
+
+<string name="presentation_with_media_router_activity_text">This activity demonstrates how to
+                  use a Presentation and the MediaRouter to automatically
+                  show content on a secondary display when available based on the currently
+                  selected media route.\n
+                  Try connecting a secondary display and watch what happens.</string>
+
+<string name="presentation_with_media_router_now_playing_locally">Now playing on main display \'%s\'.</string>
+<string name="presentation_with_media_router_now_playing_remotely">Now playing on secondary display \'%s\'.</string>
+
 </resources>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 project("xrgears")
 
 add_definitions(-DXR_OS_ANDROID)
@@ -61,3 +63,9 @@ target_link_libraries(xrgears
 )
 
 add_dependencies(xrgears shadrs)
+
+set("ANDROID")
+find_package(Libusb1 REQUIRED MODULE)
+
+target_include_directories(xrgears PUBLIC ${LIBUSB1_INCLUDE_DIRS})
+target_link_libraries(xrgears ${LIBUSB1_LIBRARIES})

--- a/src/cmake/CleanDirectoryList.cmake
+++ b/src/cmake/CleanDirectoryList.cmake
@@ -1,0 +1,49 @@
+# - Removes duplicate entries and non-directories from a provided list
+#
+#  clean_directory_list(<listvar> [<additional list items>...])
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
+
+if(__clean_directory_list)
+	return()
+endif()
+set(__clean_directory_list YES)
+
+function(clean_directory_list _var)
+	# combine variable's current value with additional list items
+	set(_in ${${_var}} ${ARGN})
+
+	if(_in)
+		# Initial list cleaning
+		list(REMOVE_DUPLICATES _in)
+
+		# Grab the absolute path of each actual directory
+		set(_out)
+		foreach(_dir ${_in})
+			if(IS_DIRECTORY "${_dir}")
+				get_filename_component(_dir "${_dir}" ABSOLUTE)
+				file(TO_CMAKE_PATH "${_dir}" _dir)
+				list(APPEND _out "${_dir}")
+			endif()
+		endforeach()
+
+		if(_out)
+			# Clean up the output list now
+			list(REMOVE_DUPLICATES _out)
+		endif()
+
+		# return _out
+		set(${_var} "${_out}" PARENT_SCOPE)
+	endif()
+endfunction()

--- a/src/cmake/FindLibusb1.cmake
+++ b/src/cmake/FindLibusb1.cmake
@@ -1,0 +1,99 @@
+# - try to find libusb-1 library
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  LIBUSB1_LIBRARY
+#  LIBUSB1_INCLUDE_DIR
+#
+# Non-cache variables you should use in your CMakeLists.txt:
+#  LIBUSB1_LIBRARIES
+#  LIBUSB1_INCLUDE_DIRS
+#  LIBUSB1_FOUND - if this is not true, do not attempt to use this library
+#
+# Requires these CMake modules:
+#  ProgramFilesGlob
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2009-2010, 2021 Ryan Pavlik <ryanpavlik@gmail.com> <abiryan@ryand.net>
+#
+# Copyright Iowa State University 2009-2010.
+# Copyright Collabora, Ltd 2021.
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+
+set(LIBUSB1_ROOT_DIR
+	"${LIBUSB1_ROOT_DIR}"
+	CACHE
+	PATH
+	"Root directory to search for libusb-1")
+
+if(WIN32)
+	include(ProgramFilesGlob)
+	program_files_fallback_glob(_dirs "LibUSB-Win32")
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		if(MSVC)
+			set(_lib_suffixes lib/msvc_x64 MS64/static)
+		endif()
+	else()
+		if(MSVC)
+			set(_lib_suffixes lib/msvc MS32/static)
+		elseif(COMPILER_IS_GNUCXX)
+			set(_lib_suffixes lib/gcc)
+		endif()
+	endif()
+else()
+	set(_lib_suffixes)
+	if(NOT ANDROID)
+		find_package(PkgConfig QUIET)
+		if(PKG_CONFIG_FOUND)
+			pkg_check_modules(PC_LIBUSB1 QUIET libusb-1.0)
+		endif()
+	endif()
+endif()
+
+find_path(LIBUSB1_INCLUDE_DIR
+	NAMES
+	libusb.h
+	PATHS
+	${PC_LIBUSB1_INCLUDE_DIRS}
+	${PC_LIBUSB1_INCLUDEDIR}
+	${_dirs}
+	HINTS
+	"${LIBUSB1_ROOT_DIR}"
+	PATH_SUFFIXES
+	include/libusb-1.0
+	include
+	libusb-1.0)
+
+find_library(LIBUSB1_LIBRARY
+	NAMES
+	libusb-1.0
+	usb-1.0
+	PATHS
+	${PC_LIBUSB1_LIBRARY_DIRS}
+	${PC_LIBUSB1_LIBDIR}
+	${_dirs}
+	HINTS
+	"${LIBUSB1_ROOT_DIR}"
+	PATH_SUFFIXES
+	${_lib_suffixes})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libusb1
+	DEFAULT_MSG
+	LIBUSB1_LIBRARY
+	LIBUSB1_INCLUDE_DIR)
+
+if(LIBUSB1_FOUND)
+	set(LIBUSB1_LIBRARIES "${LIBUSB1_LIBRARY}")
+
+	set(LIBUSB1_INCLUDE_DIRS "${LIBUSB1_INCLUDE_DIR}")
+
+	mark_as_advanced(LIBUSB1_ROOT_DIR)
+endif()
+
+mark_as_advanced(LIBUSB1_INCLUDE_DIR LIBUSB1_LIBRARY)

--- a/src/cmake/PrefixListGlob.cmake
+++ b/src/cmake/PrefixListGlob.cmake
@@ -1,0 +1,37 @@
+# - For each given prefix in a list, glob using the prefix+pattern
+#
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
+
+if(__prefix_list_glob)
+	return()
+endif()
+set(__prefix_list_glob YES)
+
+function(prefix_list_glob var pattern)
+	set(_out)
+	set(_result)
+	foreach(prefix ${ARGN})
+		file(GLOB _globbed ${prefix}${pattern})
+		if(_globbed)
+			list(SORT _globbed)
+			list(REVERSE _globbed)
+			list(APPEND _out ${_globbed})
+		endif()
+	endforeach()
+	foreach(_name ${_out})
+		get_filename_component(_name "${_name}" ABSOLUTE)
+		list(APPEND _result "${_name}")
+	endforeach()
+
+	set(${var} "${_result}" PARENT_SCOPE)
+endfunction()

--- a/src/cmake/ProgramFilesGlob.cmake
+++ b/src/cmake/ProgramFilesGlob.cmake
@@ -1,0 +1,86 @@
+# - Find bit-appropriate program files directories matching a given pattern
+#
+# Requires these CMake modules:
+#  CleanDirectoryList
+#  PrefixListGlob
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
+
+include(PrefixListGlob)
+include(CleanDirectoryList)
+
+if(__program_files_glob)
+	return()
+endif()
+set(__program_files_glob YES)
+
+macro(_program_files_glob_var_prep)
+	# caution - ENV{ProgramFiles} on Win64 is adjusted to point to the arch
+	# of the running executable which, since CMake is 32-bit on Windows as
+	# I write this, will always be = $ENV{ProgramFiles(x86)}.
+	# Thus, we only use this environment variable if we are on a 32 machine
+
+	# 32-bit dir on win32, useless to us on win64
+	file(TO_CMAKE_PATH "$ENV{ProgramFiles}" _PROG_FILES)
+
+	# 32-bit dir: only set on win64
+	set(_PF86 "ProgramFiles(x86)")
+	file(TO_CMAKE_PATH "$ENV{${_PF86}}" _PROG_FILES_X86)
+
+	# 64-bit dir: only set on win64
+	file(TO_CMAKE_PATH "$ENV{ProgramW6432}" _PROG_FILES_W6432)
+endmacro()
+
+function(program_files_glob var pattern)
+	_program_files_glob_var_prep()
+	if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+		# 64-bit build on win64
+		set(_PROGFILESDIRS "${_PROG_FILES_W6432}")
+	else()
+		if(_PROG_FILES_W6432)
+			# 32-bit build on win64
+			set(_PROGFILESDIRS "${_PROG_FILES_X86}")
+		else()
+			# 32-bit build on win32
+			set(_PROGFILESDIRS "${_PROG_FILES}")
+		endif()
+	endif()
+
+	prefix_list_glob(_prefixed "${pattern}" ${_PROGFILESDIRS})
+	clean_directory_list(_prefixed)
+	set(${var} ${_prefixed} PARENT_SCOPE)
+endfunction()
+
+function(program_files_fallback_glob var pattern)
+	_program_files_glob_var_prep()
+	if(CMAKE_SIZEOF_VOID_P MATCHES "8")
+		# 64-bit build on win64
+		# look in the "32 bit" (c:\program files (x86)\) directory as a
+		# fallback in case of weird/poorly written installers, like those
+		# that put both 64- and 32-bit libs in the same program files directory
+		set(_PROGFILESDIRS "${_PROG_FILES_W6432}" "${_PROG_FILES_X86}")
+	else()
+		if(_PROG_FILES_W6432)
+			# 32-bit build on win64
+			# look in the "64 bit" (c:\program files\) directory as a fallback
+			# in case of old/weird/poorly written installers
+			set(_PROGFILESDIRS "${_PROG_FILES_X86}" "${_PROG_FILES_W6432}")
+		else()
+			# 32-bit build on win32
+			set(_PROGFILESDIRS "${_PROG_FILES}")
+		endif()
+	endif()
+
+	prefix_list_glob(_prefixed "${pattern}" ${_PROGFILESDIRS})
+	clean_directory_list(_prefixed)
+	set(${var} ${_prefixed} PARENT_SCOPE)
+endfunction()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@
 
 #include "textures.h"
 
+#include "libusb.h"
+
 class xrgears
 {
 public:
@@ -648,6 +650,10 @@ android_main(struct android_app *state)
   android_context_init(&global_android_context, engine->app->activity->vm,
                        engine->app->activity->env,
                        engine->app->activity->clazz);
+
+  libusb_context *ctx = nullptr;
+  libusb_set_option(ctx, LIBUSB_OPTION_ANDROID_JAVAVM, engine->app->activity->vm);        // important for Android
+  libusb_init(&ctx);
 
   while (true) {
     int events;


### PR DESCRIPTION
#  Demo: XREAL Air glasses with Monado on Android

<p align="center">
<img src="https://github.com/ila-embsys/monado_demo_xrgears/assets/1484766/97608a85-1f25-4e22-8127-024aa9995f70" width="400">
</p>

The root of challenge contains two issues:

- how to move a Monado application to a USB-attached glasses screen,
- how to get IMU data from the glasses.

To resolve the first issue, the approach offers to use Presentation Activity base, to get an external display ID and pass it, by having set ActivityOptions.setLaunchDisplayId, to an Intent that runs a NativeActivity with Monado.

To resolve the second issue, the approach offers to use an additional built-in hidapi and libusb libraries. The libusb library needs to be built on a WIP version with a JNI support to provide to it an ability to requests a user's permission to a USB device access automatically.

## Changes explanation

In the AndroidManifest.xml, near the NativeActivity that will be displayed to a glasses screen, have added new one PresentationActivity that will be displayed on the phone screen.


### Main screen Presentation Activity
The new Java files based on a PresentationActivity were added for displaying on a main phone screen.
PresentationWithMediaRouterActivity.java handles external display connection and disconnection. If the screen is attached, the code creates a new one Intent to run an Activity, sets display ID and starts an Activity. The started activity is XrGears class based on UsbDPActivity. UsbDPActivity class goal is to handle USB disconnection event and finish itself if the event is happened.
The side goals are to request a USB device permission before the use of USB device by Monado. Othervice the first requests gets reject while the dialog with a request permission shows and Monado.

### Second screen Native Activity
The NativeActivity thread have to set an additional libusb option before initialization to allow the library to handle JNI calls. That's why, the main.cpp modified to include the library header and do that init calls. CMake related files are modified to bring to the code the libusb library.

## Steps to build demo

### libusb
Clone libusb on the branch with WIP JNI support and build it by changing directory to a 'libusb/android/jni' and calling the NDK build.
```shell
ndk-build APP_PLATFORM=android-29
```

Copy the built library 'libusb-1.0.so' to a NDK toolchain's '/usr/lib' sysroot location. E.g. '~/Android/Sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib'

### hidapi
Clone hidapi and create in the repo a 'build' folder and do commands to build it. E.g.:
```shell
cmake .. -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a -DANDROID_NATIVE_API_LEVEL=29 -DCMAKE_INSTALL_PREFIX=~/Android/Sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr -DBUILD_SHARED_LIBS=true
cmake --build . --target install
```
It should create in your toolchain's sysroot the 'libhidapi-libusb.so' library.

### Monado
If the libusb and hidapi libraries are installed in the toolchain root, Monado would be built with targets that require that libraries so nReal Air would be enabled. Don't forget change revision to the branch with Nreal Air support.

Install built Monado application and 'OpenXR Runtime Broker'.
Open the broker and select Monado.

### xrgears
Copy both previously built libusb1.0.so and libhidapi-libusb.so to the 'app/src/main/jniLibs/arm64-v8a' folder.
Now the demo shoule be able to builds and works.

## Steps to run demo
The Demo is quite buggy within display connection/disconnection handling. So, the steps on order that should work:
1. Connect the glasses
2. Reject Nebual USB device request access
3. Open xrgears app
4. Accept the app USB device request access
5. Monado inside the glasses. Find a cat.

## Known issues
Glasses disconnection handler invokes Activity finish, however Monado stucks in the thread due to locking on the `blockUntilNativeDiscard()` method.

The code comment tells that NativeActivity notification about finish is not implemented.
https://gitlab.freedesktop.org/monado/monado/-/blob/main/src/xrt/auxiliary/android/src/main/java/org/freedesktop/monado/auxiliary/MonadoView.java#L236-237